### PR TITLE
Bundle fixes

### DIFF
--- a/pynrfjprog/API.py
+++ b/pynrfjprog/API.py
@@ -222,6 +222,13 @@ class API(object):
             nrfjprog_dll_folder = 'osx_dylib'
             nrfjprog_dll_name = 'libnrfjprogdll.dylib'
 
+        # Try to load the library using only its name.
+        try:
+            self._lib = ctypes.cdll.LoadLibrary(nrfjprog_dll_name)
+            return;
+        except Exception as e:
+            pass
+
         nrfjprog_dll_path = os.path.join(os.path.abspath(this_dir), nrfjprog_dll_folder, nrfjprog_dll_name)
 
         if not os.path.exists(nrfjprog_dll_path):


### PR DESCRIPTION
Makes bundling the script on Windows possible. The first commit makes it so that the script initially tries to load the `.dll` without supplying the full path, while ignoring eventual errors. 

The second commit applies a workaround to a known problem when using the `multiprocessing` module in a bundled program. The workaround is directly copied from [here](https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing#multiprocessing-code-fails-when-using-a---onefile-executable-on-windows).

I don't think either of the changes will affect users who are not bundling their application. 