### PR TITLE
Fix problem with concurrent access via MultiAPI.

### DIFF
--- a/pynrfjprog/__init__.py
+++ b/pynrfjprog/__init__.py
@@ -3,4 +3,4 @@ Package marker file.
 
 """
 
-__version__ = "9.7.3" 
+__version__ = "9.7.3"

--- a/sca_pipeline.groovy
+++ b/sca_pipeline.groovy
@@ -1,0 +1,20 @@
+// This is a Jenkins pipeline file used to perform a static code analysis and automatic tagging with a new version
+// number ( in x.y.z notation) when a merge to a certain branch is made. Automatic tagging increase only last digit (z)
+// in the new version number. When you want to change first (x) or second (y) digit in the new version number you have
+// to use ALTERNATIVE_VERSION parameter in Jenkins job.
+// For the status to be visible on GitHub, you have to add "seedlabs-ateam" collaborator & add "Jenkins (Git plugin)"
+// service to your git repository.
+// During the first launch, you have to enter ALTERNATIVE_VERSION parameter.
+
+
+@Library('JenkinsMain@2.16.15')_
+
+
+pipelinePythonSCA(
+    baseBranch: "fix_problem_with_concurrent_access_via_multiapi",
+    agentLabel: "pylint",
+    pythonVersion: '3.6',
+    installFromSetup: true,
+    runPipCheck: true,
+    runUnitTests: false,
+)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ elif py3:
 
 setup(
     
-    name = 'pynrfjprog',
+    name = 'pynrfjprog-silvair',
         
     version = pynrfjprog.__version__,
     


### PR DESCRIPTION
This pull request fixes problem with concurrent access to MultiAPI. When you make two calls to MultiAPI from two different contexts then you can get `_CommandAck` for request created from different thread (e.g. you called `rtt_is_started()` and `_rtt_read()` and you get `bool` response on `_rtt_read()`). This issue occurs because two threads wait on the same `_CmdAckQueue.get()` and you don't know which will get response earlier. Proposed solution solves this problem.