### PR TITLE
Changed order of hex file search so that nrf52840 DK is flashed correctly

### DIFF
--- a/pynrfjprog/examples/highlevel_program_hex.py
+++ b/pynrfjprog/examples/highlevel_program_hex.py
@@ -35,13 +35,13 @@ def find_blinky_hex(device_family, device_version):
     """ Find the appropriate hex file to program """
 
     module_dir, module_file = os.path.split(__file__)
-    hex_file_path = os.path.join(os.path.abspath(module_dir), device_family.lower() + "_dk_blinky.hex")
+    device_version_short = device_version.split('_')[0]
+    hex_file_path = os.path.join(os.path.abspath(module_dir), device_version_short.lower() + "_dk_blinky.hex")
 
     if os.path.exists(hex_file_path):
         return hex_file_path
 
-    device_version_short = device_version.split('_')[0]
-    hex_file_path = os.path.join(os.path.abspath(module_dir), device_version_short.lower() + "_dk_blinky.hex")
+    hex_file_path = os.path.join(os.path.abspath(module_dir), device_family.lower() + "_dk_blinky.hex")
 
     if os.path.exists(hex_file_path):
         return hex_file_path


### PR DESCRIPTION
Changed order of hex file search so that nrf52840 DK is flashed correctly

PCA10056 was being flashed with nrf52_dk_blinky.hex instead of nrf52840_dk_blinky.hex due to first matching with nrf52 hex